### PR TITLE
Add initial documentation for Rust crash course

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Rust Crash Course
+
+This repository is an opinionated, practical Rust crash course. It includes:
+
+- `lessons/` — concise markdown lessons covering core Rust topics.
+- `examples/` — runnable `cargo run --example <name>` examples.
+- `exercises/` and `solutions/` — practice problems and reference solutions.
+- `src/` — a small library and demo binary used by examples and tests.
+
+Quick start:
+
+```bash
+cd rust-crash-course
+cargo build
+cargo run --example golden 3.0
+cargo test
+```
+
+Follow lessons in `lessons/` for guided learning.


### PR DESCRIPTION
Introduce a README file that outlines the structure and quick start instructions for the Rust crash course repository.